### PR TITLE
Compare transforms instead of transform.name

### DIFF
--- a/Source/DistantObject/FlareDraw.cs
+++ b/Source/DistantObject/FlareDraw.cs
@@ -108,7 +108,7 @@ namespace DistantObject
 		{
 			if (!this.IsOnFieldOfViewOf(camera)) return false;
 			if (Physics.Linecast(camera.transform.position, this.meshRenderer.bounds.center, out RaycastHit hit))
-				return hit.transform.name == this.meshRenderer.transform.name;
+				return hit.transform == this.meshRenderer.transform;
 			return true;
 		}
 	}


### PR DESCRIPTION
This should be the last use of GetName that would still be causing performance issues.